### PR TITLE
[FOR REVIEW] Add UTM persist add-on query param

### DIFF
--- a/src/shared/addons/utm-persist.ts
+++ b/src/shared/addons/utm-persist.ts
@@ -1,0 +1,39 @@
+
+const utmPersist = () => {
+  const parsedHashUrl = location.hash.replace("#", "?").replace("/?", ""); // Remove invalid characters from hash
+  const params = new URLSearchParams(location.search || parsedHashUrl); // Check for either search URL or hashed url
+  const utmParams = [];
+
+  params.forEach((value, key) => {
+    key.startsWith("utm_") && utmParams.push(key + "=" + value);
+  });
+
+  const utmParamsString = utmParams.join("&");
+
+  const anchors: NodeListOf<HTMLAnchorElement> = document.querySelectorAll("a[href]")
+
+  anchors.forEach(function (ele ,  idx) {
+    const redirectUrl = ele.href.indexOf("?") === -1 ? "?" : "&";
+    const redirectUrlWithUtm = ele.href + redirectUrl + utmParamsString;
+    ele.href = redirectUrlWithUtm;
+  });
+
+  const handleHashChange = () => {
+    if (utmParamsString) {
+      sessionStorage.setItem("mj_utm_storage", utmParamsString); // Add utm_params to storage
+    }
+
+    const checkUtmParams = window.setInterval(() => {
+      if (location.href.includes("utm_")) {
+        window.clearInterval(checkUtmParams);
+        return;
+      }
+
+      const storedUtm = sessionStorage.mj_utm_storage || null;
+
+      if (storedUtm) location.replace(location.href + "?" + storedUtm);
+    }, 100);
+  };
+
+  window.addEventListener("hashchange", handleHashChange);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -56,10 +56,15 @@ export type LiquidmMacrosParams = {
   DEVICEID: string
 }
 
+export type AddOnsParams = {
+  utmPersist: string
+}
+
 export type QueryStringParams = Partial<TransactionParams> &
   Partial<SignupParams> &
   Partial<SnowplowPluginParams> &
   Partial<LiquidmMacrosParams> &
+  Partial<AddOnsParams> &
   SnowplowParams;
 
 // Params available to the tag's query string

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -13,6 +13,12 @@ const applyV1 = (context: QueryStringContext): void => {
   tapadCookieSyncPixel();
   tapadHashSyncPixel();
 
+
+  // UTM persist add on
+  if (context.utmPersist === 'true') {
+    utmPersist()
+  }
+
   /**
    * If no event is provided, By default import carts.
    */

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -14,8 +14,12 @@ const applyV2 = (context: QueryStringContext): void => {
   tapadCookieSyncPixel();
   tapadHashSyncPixel();
 
+
+   /**UTM Persist add-on */
+  if (context.utmPersist === 'true') utmPersist()
+  
   /** For debugging in the console */
-  context.debugger === "true" && debuggerPlugin();
+  if (context.debugger === "true") debuggerPlugin()
 
   /**
    * If no event is provided, By default import carts.


### PR DESCRIPTION
# Description:

- Added `utmPersist` query param to enable `utmPersist` function.
- Modified `utmPersist` functionality on both `v1` and `v2` versions of the universal tag
- To use the `utmPersist` function simply append `utmPersist=true` in the universal tag url