### PR TITLE
Propose to include cypress test in CircleCI on staging and main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
           name: type checking
           command: npm run check
       - run:
+          name: cypress tests
+          command: npm run test
+      - run:
           name: Build
           command: npm run deploy
       - aws-s3/sync:
@@ -34,7 +37,7 @@ jobs:
       - aws-cloudfront/invalidate:
           distribution_id: E1ZEPT1NM5152K
           paths: /*
-  
+
   build-main:
     executor: the-executor
     steps:
@@ -46,6 +49,9 @@ jobs:
           name: type checking
           command: npm run check
       - run:
+          name: cypress tests
+          command: npm run test
+      - run:
           name: Build
           command: npm run deploy
       - aws-s3/sync:
@@ -55,7 +61,7 @@ jobs:
       - aws-cloudfront/invalidate:
           distribution_id: E3NZWAOF5B6J2O
           paths: /*
-  
+
 workflows:
   version: 2
   build:


### PR DESCRIPTION
# Description
- Proposal to include automated `e2e` cypress tests on CircleCI pipeline
- We are going to implement automated `e2e` testing via [Cypress ](https://www.npmjs.com/package/cypress)as our test runner. Currently, the cypress tests run as a pre-commit hook via the use of [husky](https://www.npmjs.com/package/husky). We would also like to implement the test running on CircleCI when we deploy commits to `staging` and/or `main` branch
- Feel free to take a look at his Pull request #144 , regarding how the cypress tests were set up.
