### PR TITLE
Made the snowplow tracker more dynamic

### DIFF
--- a/src/v1/snowplow/events/create-tracker.ts
+++ b/src/v1/snowplow/events/create-tracker.ts
@@ -20,7 +20,7 @@ const createTracker = ({ appId, collector, event }: QueryStringContext): void =>
   })(window, document, "script", "//mj-snowplow-static-js.s3.amazonaws.com/sp.js", "tracker");
 
   // Creates the tracker with the appId and sends events to collector url
-  window.tracker("newTracker", "cnna", `${collector}`, {
+  window.tracker("newTracker", appId, `${collector}`, {
     appId: appId,
     postPath: '/analytics/track',
     discoverRootDomain: true,

--- a/src/v2/snowplow/events/create-tracker.ts
+++ b/src/v2/snowplow/events/create-tracker.ts
@@ -16,7 +16,7 @@ const createTracker = ({ appId, collector, event }: QueryStringContext): void =>
       i.parentNode.insertBefore(c, i);
     }
   })(window, document, "script", "//mj-snowplow-static-js.s3.amazonaws.com/cnna.js", "tracker");
-  window.tracker("newTracker", "cf", collector, {
+  window.tracker("newTracker", appId, collector, {
     appId,
     postPath: '/analytics/track',
     discoverRootDomain: true,


### PR DESCRIPTION
changed the `create-tracker` files on `v1` and `v2` subdirectories from being statically defined into `appId`