### PR TITLE
Bypass adblocker using AWS API Gateway proxy URL for snowplow /sp.js endpoint

### DIFF
--- a/src/v1/snowplow/events/create-tracker.ts
+++ b/src/v1/snowplow/events/create-tracker.ts
@@ -17,7 +17,7 @@ const createTracker = ({ appId, collector, event }: QueryStringContext): void =>
       c.src = t;
       i.parentNode.insertBefore(c, i);
     }
-  })(window, document, "script", "//mj-snowplow-static-js.s3.amazonaws.com/sp.js", "tracker");
+  })(window, document, "script", "//azsx401.dmp.cnna.io/sprite.js", "tracker");
 
   // Creates the tracker with the appId and sends events to collector url
   window.tracker("newTracker", "cnna", `${collector}`, {


### PR DESCRIPTION
**Description:**
- Adblocker blocks our tracker

**Resolution**
- Use API Gateway to use other domain and to redirect to the tracker
- Proxy requests via an API gateway which will forward all requests back to `/sp.js` domain

**Assets:** https://optipilot.com/privacy/prevent-ad-blockers

**Caveat:** The next time we need to rename this URL, we might be down maximum 5 minutes because blocked Route53 needs to be deleted before creating a new alias route.

**Integrations Approval Assigned:** Edward/Jon/Kimoy

**Old Endpoint**
![image](https://github.com/MediaJel/mediajel-tracker/assets/102063244/fd22c8e3-62f3-411f-8ba8-c5d8ac49bfd7)
![image](https://github.com/MediaJel/mediajel-tracker/assets/102063244/9ed5f8b2-028c-490c-b82e-b56cd6538b0b)


new Endpoint
![image](https://github.com/MediaJel/mediajel-tracker/assets/102063244/14fa8b59-e87a-48f0-8323-1c066db8f43c)
![image](https://github.com/MediaJel/mediajel-tracker/assets/102063244/0d96ef83-8dff-4740-964d-e7b9dd278b80)
