### PR TITLE
Update mediajel-tracker legacy carts to use new callback design pattern

### DIFF
--- a/src/shared/environment-data-sources/bigcommerce.ts
+++ b/src/shared/environment-data-sources/bigcommerce.ts
@@ -2,48 +2,46 @@ import { EnvironmentEvents, TransactionCartItem } from "../types";
 import { xhrResponseSource } from "../sources/xhr-response-source";
 
 const bigcommerceDataSource = ({ transactionEvent }: Partial<EnvironmentEvents>) => {
-    xhrResponseSource((xhr) => {
-        try {
-            //if (window.location.pathname.includes('/checkout')) {
-            const transaction = JSON.parse(JSON.stringify(JSON.parse(xhr.responseText)));
-            const products = transaction?.lineItems?.physicalItems;
-            const getLatestOrder = localStorage.getItem("latestOrder");
-            if (transaction.hasOwnProperty("orderId")) {
-                if (transaction.hasOwnProperty("status")) {
-                    if (transaction.status === "AWAITING_FULFILLMENT") {
-                        if (getLatestOrder !== transaction.orderId.toString()) {
-                            transactionEvent({
-                                id: transaction.orderId.toString(),
-                                total: parseFloat(transaction.orderAmount),
-                                tax: parseFloat(transaction.taxTotal) || 0,
-                                shipping: parseFloat(transaction.shippingCostTotal) || 0,
-                                city: (transaction.billingAddress.city || "N/A").toString(),
-                                state: (transaction.billingAddress.stateOrProvinceCode || "N/A").toString(),
-                                country: (transaction.billingAddress.countryCode || "N/A").toString(),
-                                currency: "USD",
-                                items: products.map((product) => {
-                                    const { productId, sku, name, listPrice, quantity } = product;
-                                    return {
-                                        orderId: transaction.orderId.toString(),
-                                        productId: productId.toString(),
-                                        sku: sku.toString(),
-                                        name: (name || "N/A").toString(),
-                                        category: "N/A",
-                                        unitPrice: parseFloat(listPrice || 0),
-                                        quantity: parseInt(quantity || 1),
-                                        currency: "USD",
-                                    } as TransactionCartItem;
-                                }),
-                            });
-                            localStorage.setItem("latestOrder", transaction.orderId.toString());
-                        }
-                    }
-                }
+  xhrResponseSource((xhr) => {
+    try {
+      //if (window.location.pathname.includes('/checkout')) {
+      const transaction = JSON.parse(JSON.stringify(JSON.parse(xhr.responseText)));
+      const products = transaction?.lineItems?.physicalItems;
+      const getLatestOrder = localStorage.getItem("latestOrder");
+      if (transaction.hasOwnProperty("orderId")) {
+        if (transaction.hasOwnProperty("status")) {
+          if (transaction.status === "AWAITING_FULFILLMENT") {
+            if (getLatestOrder !== transaction.orderId.toString()) {
+              transactionEvent({
+                id: transaction.orderId.toString(),
+                total: parseFloat(transaction.orderAmount),
+                tax: parseFloat(transaction.taxTotal) || 0,
+                shipping: parseFloat(transaction.shippingCostTotal) || 0,
+                city: (transaction.billingAddress.city || "N/A").toString(),
+                state: (transaction.billingAddress.stateOrProvinceCode || "N/A").toString(),
+                country: (transaction.billingAddress.countryCode || "N/A").toString(),
+                currency: "USD",
+                items: products.map((product) => {
+                  const { productId, sku, name, listPrice, quantity } = product;
+                  return {
+                    orderId: transaction.orderId.toString(),
+                    sku: sku.toString(),
+                    name: (name || "N/A").toString(),
+                    category: "N/A",
+                    unitPrice: parseFloat(listPrice || 0),
+                    quantity: parseInt(quantity || 1),
+                    currency: "USD",
+                  } as TransactionCartItem;
+                }),
+              });
+              localStorage.setItem("latestOrder", transaction.orderId.toString());
             }
-            //}
-        } catch (e) {
+          }
         }
-    });
+      }
+      //}
+    } catch (e) {}
+  });
 };
 
 export default bigcommerceDataSource;

--- a/src/shared/environment-data-sources/shopify.ts
+++ b/src/shared/environment-data-sources/shopify.ts
@@ -26,26 +26,18 @@ const shopifyDataSource = ({ transactionEvent }: Pick<EnvironmentEvents, "transa
     currency: (transaction.currency || "N/A").toString(),
     items: products.map((product: any) => {
       const { id, product_id, title, variant_title, price, quantity } = product;
-      return {} as TransactionCartItem;
+      return {
+        orderId: (transaction.liquid_order_name || transaction.order_id).toString(),
+        productId: (id || product_id).toString(),
+        sku: (id || product_id).toString(),
+        name: (title || "N/A").toString(),
+        category: "N/A", // No Category Field for Shopify in transactionItems
+        unitPrice: parseFloat(price || 0),
+        quantity: parseInt(quantity || 1),
+        currency: (transaction.currency || "USD").toString(),
+      } as TransactionCartItem;
     }),
   });
-
-  products.forEach((items) => {
-    const { id, product_id, title, variant_title, price, quantity } = items;
-
-    window.tracker(
-      "addItem",
-      (transaction.liquid_order_name || transaction.order_id).toString(),
-      (id || product_id).toString(),
-      (title || "N/A").toString(),
-      (variant_title || "N/A").toString(),
-      parseFloat(price || 0),
-      parseInt(quantity || 1),
-      (transaction.currency || "USD").toString()
-    );
-  });
-
-  window.tracker("trackTrans");
 };
 
 export default shopifyDataSource;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,7 @@ export interface CartEvent {
   quantity: number;
   currency: string;
   userId?: string;
+  productId?: string;
 }
 
 export interface TransactionCartItem extends CartEvent {
@@ -109,8 +110,6 @@ export type ImpressionsMacrosParams = {
 export type LiquidmSegmentParams = {
   segmentId: string;
 };
-
-
 
 export type QueryStringParams = Partial<TransactionParams> &
   Partial<SignupParams> &

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,7 +6,6 @@ export interface CartEvent {
   quantity: number;
   currency: string;
   userId?: string;
-  productId?: string;
 }
 
 export interface TransactionCartItem extends CartEvent {

--- a/src/v1/imports/carts/bigcommerce.ts
+++ b/src/v1/imports/carts/bigcommerce.ts
@@ -21,7 +21,6 @@ const bigcommerceTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/bigcommerce.ts
+++ b/src/v1/imports/carts/bigcommerce.ts
@@ -1,37 +1,38 @@
-import { xhrResponseSource } from "../../../shared/sources/xhr-response-source";
 import { QueryStringContext } from "../../../shared/types";
-import bigcommerceDataSource from "../../../shared/environment-data-sources/bigcommerce"
+import bigcommerceDataSource from "../../../shared/environment-data-sources/bigcommerce";
 
 const bigcommerceTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-    bigcommerceDataSource({
-        transactionEvent(transactionData) {
-            window.tracker(
-              "addTrans",
-              transactionData.id,
-              retailId ?? appId,
-              transactionData.total,
-              transactionData.tax,
-              transactionData.shipping,
-              transactionData.city,
-              transactionData.state,
-              transactionData.country
-            );
-      
-            transactionData.items.forEach((item) => {
-              window.tracker(
-                "addItem",
-                transactionData.id,
-                item.sku,
-                item.name,
-                item.category,
-                item.unitPrice,
-                item.quantity,
-                transactionData.currency
-              );
-            });
-            window.tracker("trackTrans");
-          },
-    });
+  bigcommerceDataSource({
+    transactionEvent(transactionData) {
+      window.tracker(
+        "addTrans",
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
+      );
+
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          transactionData.id,
+          item.productId,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          transactionData.currency
+        );
+      });
+      window.tracker("trackTrans");
+    },
+  });
 };
 
 export default bigcommerceTracker;

--- a/src/v1/imports/carts/buddi.ts
+++ b/src/v1/imports/carts/buddi.ts
@@ -45,7 +45,6 @@ const buddiTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "r
         window.tracker(
           "addItem",
           item.orderId,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/dispense.ts
+++ b/src/v1/imports/carts/dispense.ts
@@ -13,7 +13,8 @@ const dispenseTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" |
         transactionData.shipping,
         transactionData.city,
         transactionData.state,
-        transactionData.country
+        transactionData.country,
+        transactionData.currency
       );
 
       transactionData.items.forEach((item) => {

--- a/src/v1/imports/carts/dutchie-iframe.ts
+++ b/src/v1/imports/carts/dutchie-iframe.ts
@@ -45,7 +45,6 @@ const dutchieIframeTracker = ({ appId, retailId }: Pick<QueryStringContext, "app
         window.tracker(
           "addItem",
           item.orderId,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/dutchie-plus.ts
+++ b/src/v1/imports/carts/dutchie-plus.ts
@@ -13,7 +13,8 @@ const dutchiePlusTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId
         transactionData.shipping,
         transactionData.city,
         transactionData.state,
-        transactionData.country
+        transactionData.country,
+        transactionData.currency
       );
 
       transactionData.items.forEach((item) => {

--- a/src/v1/imports/carts/dutchie-subdomain.ts
+++ b/src/v1/imports/carts/dutchie-subdomain.ts
@@ -1,88 +1,58 @@
+import dutchieSubdomainDataSource from "src/shared/environment-data-sources/dutchie-subdomain";
 import { QueryStringContext } from "../../../shared/types";
 
-const dutchieSubdomainTracker = ({
-  appId,
-  retailId,
-}: Pick<QueryStringContext, "appId" | "retailId">) => {
-  const dataLayer = window.dataLayer || [];
-
-  function onDataLayerChange() {
-    const data = dataLayer.slice(-1)[0]; // Gets the newest array member of dataLayer
-
-    if (data.event === "add_to_cart") {
-      const products = data.ecommerce.items;
-      const { item_id, item_name, item_category, price, quantity } = products[0];
-
+const dutchieSubdomainTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
+  dutchieSubdomainDataSource({
+    addToCartEvent(addToCartData) {
       window.tracker(
         "trackAddToCart",
-        item_id.toString(),
-        (item_name || "N/A").toString(),
-        (item_category || "N/A").toString(),
-        parseFloat(price || 0),
-        parseInt(quantity || 1),
-        "USD"
+        addToCartData.sku,
+        addToCartData.name,
+        addToCartData.category,
+        addToCartData.unitPrice,
+        addToCartData.quantity,
+        addToCartData.currency
       );
-    }
-
-    if (data.event === "remove_from_cart") {
-      const products = data.ecommerce.items;
-      const { item_id, item_name, item_category, price, quantity } = products[0];
-
+    },
+    removeFromCartEvent(removeFromCartData) {
       window.tracker(
         "trackRemoveFromCart",
-        item_id.toString(),
-        (item_name || "N/A").toString(),
-        (item_category || "N/A").toString(),
-        parseFloat(price || 0),
-        parseInt(quantity || 1),
-        "USD"
+        removeFromCartData.sku,
+        removeFromCartData.name,
+        removeFromCartData.category,
+        removeFromCartData.unitPrice,
+        removeFromCartData.quantity,
+        removeFromCartData.currency
       );
-    }
+    },
 
-    if (data.event === "purchase") {
-      const transaction = data.ecommerce;
-      const products = transaction.items;
-      const { transaction_id, value } = transaction;
-
-      // Hardcoded because most fields are empty
+    transactionEvent(transactionData) {
       window.tracker(
         "addTrans",
-        transaction_id.toString(),
+        transactionData.id,
         retailId ?? appId,
-        parseFloat(value),
-        0,
-        0,
-        "N/A",
-        "N/A",
-        "N/A",
-        "USD"
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country
       );
 
-      products.forEach(items => {
-        const { item_id, item_name, item_category, price, quantity } = items;
-
+      transactionData.items.forEach((item) => {
         window.tracker(
           "addItem",
-          transaction_id.toString(),
-          item_id.toString(),
-          (item_name || "N/A").toString(),
-          (item_category || "N/A").toString(),
-          parseFloat(price || 0),
-          parseInt(quantity || 1),
-          "USD"
+          transactionData.id,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          transactionData.currency
         );
       });
-
-      window.tracker('trackTrans');
-    }
-  }
-
-  // Stores the original dataLayer.push method before modifying it to execute our snowplow tracker
-  const originalPush = dataLayer.push
-  dataLayer.push = function (...args) {
-    originalPush(...args);
-    onDataLayerChange();
-  };
+      window.tracker("trackTrans");
+    },
+  });
 };
-
 export default dutchieSubdomainTracker;

--- a/src/v1/imports/carts/ecwid.ts
+++ b/src/v1/imports/carts/ecwid.ts
@@ -1,54 +1,37 @@
 import { QueryStringContext } from "../../../shared/types";
-import { tryParseJSONObject } from "../../../shared/utils/try-parse-json";
+import ecwidTrackerImport from "src/shared/environment-data-sources/ecwid";
 
 const ecwidTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  if (!window.transactionOrder && !window.transactionItems) {
-    return;
-  }
-  const transaction = tryParseJSONObject(window.transactionOrder);
-  const products = tryParseJSONObject(window.transactionItems);
-
-  const orderTotal = transaction.orderTotal.substring(1);
-  const orderSubtotalWithoutTax = transaction.orderSubtotalWithoutTax.substring(1);
-  const orderSubtotal = transaction.orderSubtotal.substring(1); // just in case for future use
-  const orderShippingCost = transaction.orderShippingCost.substring(1);
-  const transactionTax = Math.abs(orderTotal - orderSubtotalWithoutTax);
-
-  if (window.transactionEmail) {
-    const email = window.transactionEmail || "N/A";
-    window.tracker("setUserId", (email).toString());
-  }
-
-  window.tracker(
-    "addTrans",
-    transaction.orderNumber.toString(),
-    retailId || appId,
-    parseFloat(orderTotal),
-    transactionTax,
-    parseFloat(orderShippingCost || 0),
-    "N/A", // TODO: GET BILLING/SHIPPING ADDRESSES FOR ECWID
-    "N/A",
-    "N/A",
-    "USD"
-  );
-
-  products.forEach((items) => {
-    const { orderItemName, orderItemSku, orderItemPrice, orderItemQuantity } = items;
-    const itemPrice = orderItemPrice.substring(1);
-
-    window.tracker(
-      "addItem",
-      transaction.orderNumber.toString(),
-      orderItemSku.toString(),
-      (orderItemName || "N/A").toString(),
-      "N/A", // No Category Field for Ecwid in transactionItems
-      parseFloat(itemPrice || 0),
-      parseInt(orderItemQuantity || 1),
-      "USD"
-    );
+  ecwidTrackerImport({
+    transactionEvent(transactionData) {
+      window.tracker(
+        "addTrans",
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
+      );
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          transactionData.id,
+          item.productId,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          item.currency
+        );
+      });
+      window.tracker("trackTrans");
+    },
   });
-
-  window.tracker("trackTrans");
 };
 
 export default ecwidTracker;

--- a/src/v1/imports/carts/ecwid.ts
+++ b/src/v1/imports/carts/ecwid.ts
@@ -20,7 +20,6 @@ const ecwidTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "r
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/grassdoor.ts
+++ b/src/v1/imports/carts/grassdoor.ts
@@ -1,86 +1,62 @@
 import { QueryStringContext } from "../../../shared/types";
+import grassDoorTracker from "src/shared/environment-data-sources/grassdoor";
 
 const greendoorTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  const dataLayer = window.dataLayer || [];
-
-  function onDataLayerChange() {
-    const data = window.dataLayer.slice(-1)[0]; // Gets the newest array member of dataLayer
-
-    if (data.event === "Product Added") {
-      const products = data;
-      const { sku, name, price, quantity, category } = products;
-
+  grassDoorTracker({
+    addToCartEvent(addToCartData) {
       window.tracker(
         "trackAddToCart",
-        sku.toString(),
-        (name || "N/A").toString(),
-        (category || "N/A").toString(),
-        parseFloat(price || 0),
-        parseInt(quantity || 1),
-        "USD"
+        addToCartData.sku,
+        addToCartData.name,
+        addToCartData.category,
+        addToCartData.unitPrice,
+        addToCartData.quantity,
+        addToCartData.currency
       );
-    }
+    },
 
-    if (data.event === "Product Removed") {
-      const products = data;
-      const { sku, name, price, quantity, category } = products;
-
+    removeFromCartEvent(cartData) {
       window.tracker(
         "trackRemoveFromCart",
-        sku.toString(),
-        (name || "N/A").toString(),
-        (category || "N/A").toString(),
-        parseFloat(price || 0),
-        parseInt(quantity || 1),
-        "USD"
+        cartData.sku,
+        cartData.name,
+        cartData.category,
+        cartData.unitPrice,
+        cartData.quantity,
+        cartData.currency
       );
-    }
+    },
 
-    if (data.event === "Order Made") {
-      const transaction_id = data.order_id;
-      const transaction_total = data.revenue;
-      const transaction_tax = data.tax;
-      const transaction_shipping = data.shipping;
-      const products = data.products;
-
+    transactionEvent(transactionData) {
       window.tracker(
         "addTrans",
-        transaction_id.toString(),
+        transactionData.id,
         retailId ?? appId,
-        parseFloat(transaction_total || 0),
-        parseFloat(transaction_tax || 0),
-        parseFloat(transaction_shipping || 0),
-        "N/A",
-        "N/A",
-        "N/A",
-        "USD"
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
       );
 
-      products.forEach((items) => {
-        const { product_id, name, price, quantity, category } = items;
-
+      transactionData.items.forEach((item) => {
         window.tracker(
           "addItem",
-          transaction_id.toString(),
-          product_id.toString(),
-          (name || "N/A").toString(),
-          (category || "N/A").toString(),
-          parseFloat(price || 0),
-          parseInt(quantity || 1),
-          "USD"
+          transactionData.id,
+          item.productId,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          item.currency
         );
       });
-
       window.tracker("trackTrans");
-    }
-  }
-
-  // Stores the original dataLayer.push method before modifying it to execute our snowplow tracker
-  const originalPush = dataLayer.push;
-  dataLayer.push = function (...args) {
-    originalPush(...args);
-    onDataLayerChange();
-  };
+    },
+  });
 };
 
 export default greendoorTracker;

--- a/src/v1/imports/carts/grassdoor.ts
+++ b/src/v1/imports/carts/grassdoor.ts
@@ -45,7 +45,6 @@ const greendoorTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" 
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/greenrush.ts
+++ b/src/v1/imports/carts/greenrush.ts
@@ -1,45 +1,37 @@
 import { QueryStringContext } from "../../../shared/types";
+import greenrushDataSource from "src/shared/environment-data-sources/greenrush";
 
 const greenrushTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  (function () {
-    var origOpen = XMLHttpRequest.prototype.open;
-    XMLHttpRequest.prototype.open = function () {
-      this.addEventListener("load", function () {
-        var response = this.responseText;
-        if (this.responseURL.includes("cart") && this.response.includes("pending")) {
-          var transaction = JSON.parse(response);
-          var product = transaction.data.items.data;
-          window.tracker(
-            "addTrans",
-            transaction.data.id.toString(),
-            !retailId ? appId : retailId,
-            parseFloat(transaction.data.total),
-            parseFloat(transaction.data.tax),
-            0,
-            "N/A",
-            "N/A",
-            "USA",
-            "USD"
-          );
-          for (var i = 0, l = product.length; i < l; i++) {
-            var item = product[i];
-            window.tracker(
-              "addItem",
-              transaction.data.id.toString(),
-              item.id.toString(),
-              item.name.toString(),
-              item.category.toString(),
-              parseFloat(item.price),
-              parseInt(item.quantity),
-              "USD"
-            );
-          }
-          window.tracker("trackTrans");
-        }
+  greenrushDataSource({
+    transactionEvent(transactionData) {
+      window.tracker(
+        "addTrans",
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
+      );
+
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          transactionData.id,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          transactionData.currency
+        );
       });
-      origOpen.apply(this, arguments);
-    };
-  })();
+      window.tracker("trackTrans");
+    },
+  });
 };
 
 export default greenrushTracker;

--- a/src/v1/imports/carts/jane.ts
+++ b/src/v1/imports/carts/jane.ts
@@ -1,72 +1,61 @@
 import { QueryStringContext } from "../../../shared/types";
+import janeDataSource from "src/shared/environment-data-sources/jane";
 
 const janeTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  function receiveMessage(event: MessageEvent<any>) {
-    const { payload, messageType } = event.data;
-
-    if (!payload || messageType !== "analyticsEvent") {
-      return;
-    }
-
-    if (payload.name === "cartItemAdd") {
-      const { product, productId } = payload.properties;
-
+  janeDataSource({
+    addToCartEvent(cartData) {
       window.tracker(
         "trackAddToCart",
-        productId.toString(),
-        (product.name || "N/A").toString(),
-        (product.category || "N/A").toString(),
-        parseFloat(product.unit_price || 0),
-        parseInt(product.count || 1),
-        "USD"
+        cartData.sku,
+        cartData.name,
+        cartData.category,
+        cartData.unitPrice,
+        cartData.quantity,
+        cartData.currency
       );
-    }
+    },
 
-    if (payload.name === "cartItemRemoval") {
-      const { productId } = payload.properties;
+    removeFromCartEvent(cartData) {
+      window.tracker(
+        "trackRemoveFromCart",
+        cartData.sku,
+        cartData.name,
+        cartData.category,
+        cartData.unitPrice,
+        cartData.quantity,
+        cartData.currency
+      );
+    },
 
-      // Hardcoded because most fields are empty
-      window.tracker("trackRemoveFromCart", productId.toString(), "N/A", "N/A", 0, 1, "USD");
-    }
-
-    if (payload.name === "checkout") {
-      const { customerEmail, products, cartId, estimatedTotal, deliveryFee, deliveryAddress = {}, salesTax, storeTax } = payload.properties;
-
-      window.tracker("setUserId", customerEmail);
-
+    transactionEvent(transactionData) {
       window.tracker(
         "addTrans",
-        cartId.toString(),
-        retailId || appId,
-        parseFloat(estimatedTotal),
-        parseFloat(salesTax + storeTax || 0),
-        parseFloat(deliveryFee || 0),
-        (deliveryAddress?.city || "N/A").toString(),
-        (deliveryAddress?.state_code || "N/A").toString(),
-        (deliveryAddress?.country_code || "N/A").toString(),
-        "USD"
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
       );
 
-      products.forEach((items) => {
-        const { product_id, name, category, unit_price, count } = items;
-
+      transactionData.items.forEach((item) => {
         window.tracker(
           "addItem",
-          cartId.toString(),
-          product_id.toString(),
-          (name || "N/A").toString(),
-          (category || "N/A").toString(),
-          parseFloat(unit_price || 0),
-          parseInt(count || 1),
-          "USD"
+          transactionData.id,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          item.currency
         );
       });
-
       window.tracker("trackTrans");
-    }
-  }
-
-  window.addEventListener("message", receiveMessage, false);
+    },
+  });
 };
 
 export default janeTracker;

--- a/src/v1/imports/carts/lightspeed.ts
+++ b/src/v1/imports/carts/lightspeed.ts
@@ -21,7 +21,6 @@ const lightspeedTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId"
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/lightspeed.ts
+++ b/src/v1/imports/carts/lightspeed.ts
@@ -1,42 +1,38 @@
 import { QueryStringContext } from "../../../shared/types";
+import lightspeedTrackerImport from "src/shared/environment-data-sources/lightspeed";
 
-const lightspeedTracker = ({
-  appId,
-  retailId,
-}: Pick<QueryStringContext, "appId" | "retailId">) => {
-  if (!window.lightspeedTransaction) return;
-  else {
-    const transaction = window.lightspeedTransaction;
-    const products = transaction.products;
-
-    window.tracker(
-      "addTrans",
-      transaction.orderNumber.toString(),
-      !retailId ? appId : retailId,
-      parseFloat(transaction.orderTotal),
-      parseFloat(transaction.orderTax ? transaction.orderTax : 0),
-      parseFloat(transaction.orderShipping ? transaction.orderShipping : 0),
-      (transaction.orderCity ? transaction.orderCity : "N/A").toString(),
-      (transaction.orderRegion ? transaction.orderRegion : "N/A").toString(),
-      (transaction.orderCountry ? transaction.orderCountry : "N/A").toString(),
-      (transaction.orderCurrency ? transaction.orderCurrency : "USD").toString()
-    );
-
-    for (let i = 0; i < products.length; ++i) {
+const lightspeedTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
+  lightspeedTrackerImport({
+    transactionEvent(transactionData) {
       window.tracker(
-        "addItem",
-        transaction.orderNumber.toString(),
-        products[i].productId.toString(),
-        (products[i].productName ? products[i].productName : "N/A").toString(),
-        (products[i].productCategory ? products[i].productCategory : "N/A").toString(),
-        parseFloat(products[i].productPrice),
-        parseInt(products[i].productQuantity ? products[i].productQuantity : 1),
-        (transaction.orderCurrency ? transaction.orderCurrency : "USD").toString()
+        "addTrans",
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
       );
-    }
 
-    window.tracker("trackTrans");
-  }
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          transactionData.id,
+          item.productId,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          item.currency
+        );
+      });
+      window.tracker("trackTrans");
+    },
+  });
 };
 
 export default lightspeedTracker;

--- a/src/v1/imports/carts/meadow.ts
+++ b/src/v1/imports/carts/meadow.ts
@@ -45,7 +45,6 @@ const meadowTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/olla.ts
+++ b/src/v1/imports/carts/olla.ts
@@ -45,7 +45,6 @@ const ollaTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "re
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/shopify.ts
+++ b/src/v1/imports/carts/shopify.ts
@@ -1,50 +1,39 @@
 import { QueryStringContext } from "../../../shared/types";
+import shopifyDataSource from "src/shared/environment-data-sources/shopify";
 
 const shopifyTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  console.log("Shopify tracker called");
-  if (!window.Shopify.checkout) {
-    return;
-  }
+  shopifyDataSource({
+    transactionEvent(transactionData) {
+      window.tracker(
+        "addTrans",
+        transactionData.userId,
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
+      );
 
-  console.log("Window.Shopify.checkout", window.Shopify.checkout);
-
-  const transaction = window.Shopify.checkout;
-  const products = transaction.line_items;
-  const email = transaction.email || "N/A";
-  const orderNumber = document.getElementsByClassName("os-order-number")[0]["innerText"] || "";
-
-  window.tracker("setUserId", email);
-
-  // liquid_total_price is legacy support for old shopify integration
-  window.tracker(
-    "addTrans",
-    `${(transaction.liquid_order_name || transaction.order_id).toString()} ${orderNumber && `- ${orderNumber}`}`,
-    retailId ?? appId,
-    parseFloat(transaction.liquid_total_price || transaction.total_price),
-    parseFloat(transaction.total_tax || 0),
-    parseFloat(transaction.shipping_rate.price || 0),
-    (transaction.billing_address.city || "N/A").toString(),
-    (transaction.billing_address.province || "N/A").toString(),
-    (transaction.billing_address.country || "N/A").toString(),
-    (transaction.currency || "USD").toString()
-  );
-
-  products.forEach((items) => {
-    const { id, product_id, title, variant_title, price, quantity } = items;
-
-    window.tracker(
-      "addItem",
-      `${(transaction.liquid_order_name || transaction.order_id).toString()} ${orderNumber && `- ${orderNumber}`}`,
-      (id || product_id).toString(),
-      (title || "N/A").toString(),
-      (variant_title || "N/A").toString(),
-      parseFloat(price || 0),
-      parseInt(quantity || 1),
-      (transaction.currency || "USD").toString()
-    );
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          item.orderId,
+          item.productId,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          item.currency
+        );
+      });
+      window.tracker("trackTrans");
+    },
   });
-
-  window.tracker("trackTrans");
 };
 
 export default shopifyTracker;

--- a/src/v1/imports/carts/shopify.ts
+++ b/src/v1/imports/carts/shopify.ts
@@ -22,7 +22,6 @@ const shopifyTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | 
         window.tracker(
           "addItem",
           item.orderId,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/wefunder.ts
+++ b/src/v1/imports/carts/wefunder.ts
@@ -1,28 +1,37 @@
-import { xhrResponseSource } from "../../../shared/sources/xhr-response-source";
 import { QueryStringContext } from "../../../shared/types";
+import wefunderTrackerImport from "src/shared/environment-data-sources/wefunder";
 
 const wefunderTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  xhrResponseSource((xhr) => {
-    if (xhr.responseURL.includes("investments") && typeof xhr.responseText === "string") {
-      const data = JSON.parse(xhr?.responseText);
-
-      window.tracker("setUserId", data?.investment?.user_id || data?.investment?.investor_name);
-
+  wefunderTrackerImport({
+    transactionEvent(transactionData) {
       window.tracker(
         "addTrans",
-        data?.investment?.id.toString(),
+        transactionData.id,
         retailId ?? appId,
-        parseFloat(data?.investment?.amount),
-        0,
-        0,
-        "N/A",
-        "N/A",
-        "N/A",
-        "USD"
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency
       );
 
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          transactionData.id,
+          item.productId,
+          item.sku,
+          item.name,
+          item.category,
+          item.unitPrice,
+          item.quantity,
+          item.currency
+        );
+      });
       window.tracker("trackTrans");
-    }
+    },
   });
 };
 

--- a/src/v1/imports/carts/wefunder.ts
+++ b/src/v1/imports/carts/wefunder.ts
@@ -21,7 +21,6 @@ const wefunderTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" |
         window.tracker(
           "addItem",
           transactionData.id,
-          item.productId,
           item.sku,
           item.name,
           item.category,

--- a/src/v1/imports/carts/woocommerce.ts
+++ b/src/v1/imports/carts/woocommerce.ts
@@ -1,45 +1,37 @@
 import { QueryStringContext } from "../../../shared/types";
-import { tryParseJSONObject } from "../../../shared/utils/try-parse-json";
+import woocommerceDataSource from "src/shared/environment-data-sources/woocommerce";
 
 const woocommerceTracker = ({ appId, retailId }: Pick<QueryStringContext, "appId" | "retailId">) => {
-  if (!window.transactionOrder && !window.transactionItems) {
-    return;
-  }
-  const transaction = tryParseJSONObject(window.transactionOrder);
-  const products = tryParseJSONObject(window.transactionItems);
-  const email = transaction.billing.email || "N/A";
+  woocommerceDataSource({
+    transactionEvent(transactionData) {
+      window.tracker(
+        "addTrans",
+        transactionData.id,
+        retailId ?? appId,
+        transactionData.total,
+        transactionData.tax,
+        transactionData.shipping,
+        transactionData.city,
+        transactionData.state,
+        transactionData.country,
+        transactionData.currency,
+        transactionData.userId
+      );
 
-  window.tracker("setUserId", email);
-
-  window.tracker(
-    "addTrans",
-    (transaction.id || transaction.transaction_id).toString(),
-    retailId || appId,
-    parseFloat(transaction.total),
-    parseFloat(transaction.total_tax || 0),
-    parseFloat(transaction.shipping_total || 0),
-    (transaction.billing.city || "N/A").toString(),
-    (transaction.billing.state || "N/A").toString(),
-    (transaction.billing.country || "N/A").toString(),
-    (transaction.currency || "USD").toString()
-  );
-
-  products.forEach((items) => {
-    const { order_id, name, product_id, total, quantity } = items;
-
-    window.tracker(
-      "addItem",
-      (transaction.id || order_id).toString(),
-      product_id.toString(),
-      (name || "N/A").toString(),
-      "N/A", // No Category Field for WooCommerce in transactionItems
-      parseFloat(total),
-      parseInt(quantity || 1),
-      (transaction.currency || "USD").toString()
-    );
+      transactionData.items.forEach((item) => {
+        window.tracker(
+          "addItem",
+          transactionData.id,
+          item.sku,
+          item.name,
+          item.category,
+          item.quantity,
+          item.unitPrice,
+          item.currency
+        );
+      });
+    },
   });
-
-  window.tracker("trackTrans");
 };
 
 export default woocommerceTracker;


### PR DESCRIPTION
# Description
We want to update the old mediajel-tracker carts to use the new design pattern of separating the logic of capturing the events vs the logic of tracking the event.

## Carts Updated
* Woocommerce
* Wefunder
* Tymber
* Shopify
* Olla
* Meadow
* Lightspeed
* Jane
* Greenrush
* Grassdoor
* Ecwid
* Dutchie-Subdomain
* Dutchie-Plus
* Dutchie-Iframe
* Dispense
* Buddi
* Bigcommerce

## Carts Left Untouched
These carts were already using the new callback design pattern.

* Yotpo
* Webjoint
* Sticky-Leaf
* Square
* Magento
* Yotpo
* Webjoint
* Sticky-Leaf
* Square
* Magento
