### PR TITLE
DEVOPS: Increase browser cache expiration to 1 month

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - aws-s3/sync:
           from: dist/
           to: "s3://mediajel-tracker-staging"
-          arguments: --cache-control "max-age=259200"
+          arguments: --cache-control "max-age=2628288"
       - aws-cloudfront/invalidate:
           distribution_id: E1ZEPT1NM5152K
           paths: /*
@@ -63,7 +63,7 @@ jobs:
       - aws-s3/sync:
           from: dist/
           to: "s3://mediajel-tracker-production"
-          arguments: --cache-control "max-age=259200"
+          arguments: --cache-control "max-age=2628288"
       - aws-cloudfront/invalidate:
           distribution_id: E3NZWAOF5B6J2O
           paths: /*


### PR DESCRIPTION
Every 3 days, our CloudFront cost is spiking because browser cache is only valid for 3 days.

Increase browser cache expiration to 1 month for cost-savings purposes.