### PR TITLE
if tax is not a number then make it 0

### DIFF
--- a/src/shared/environment-data-sources/dutchie-subdomain.ts
+++ b/src/shared/environment-data-sources/dutchie-subdomain.ts
@@ -112,7 +112,7 @@ const dutchieSubdomainDataSource = () => {
         transactionEvent: {
           total: parseFloat(transaction_total),
           id: transaction_id.toString(),
-          tax: transaction_tax || 0,
+          tax: transaction_tax === "N/A" || isNaN(transaction_tax) ? 0 : parseFloat(transaction_tax),
           shipping: 0,
           city: "N/A",
           state: "N/A",


### PR DESCRIPTION
This pull request includes a change to the `dutchieSubdomainDataSource` function in the `src/shared/environment-data-sources/dutchie-subdomain.ts` file to improve the handling of transaction tax values.

Handling of transaction tax values:

* [`src/shared/environment-data-sources/dutchie-subdomain.ts`](diffhunk://#diff-fc6e3125a9aae35d7ea7c023d223c64e44130addd58b36fe5a46a9476cb7982aL115-R115): Modified the `tax` field to set it to 0 if `transaction_tax` is "N/A" or not a number.