### PR TITLE
added dutchie adapter

### DIFF
--- a/src/adapters/ecommerce.ts
+++ b/src/adapters/ecommerce.ts
@@ -40,19 +40,9 @@ export default async (tracker: SnowplowTracker): Promise<void> => {
       // description: "drupal is just a test description"
       // events-tracked: [{ "value": "transaction", "label": "Transaction" }]
       break;
-    case "dutchie-iframe":
-      import("../shared/environment-data-sources/dutchie-iframe").then(({ default: load }): void => load());
-      // description: "dutchie-iframe is a just a test description"
-      // events-tracked: [{ value: "add_to_cart", label: "Add to Cart" }, { value: "remove_from_cart", label: "Remove from Cart" }, { "value": "transaction", "label": "Transaction" }]
-      break;
-    case "dutchie-subdomain":
-      import("../shared/environment-data-sources/dutchie-subdomain").then(({ default: load }): void => load());
-      // description: "dutchie-subdomain is a just a test description"
-      // events-tracked: [{ value: "add_to_cart", label: "Add to Cart" }, { value: "remove_from_cart", label: "Remove from Cart" }, { "value": "transaction", "label": "Transaction" }]
-      break;
-    case "dutchieplus":
-      import("../shared/environment-data-sources/dutchie-plus").then(({ default: load }): void => load());
-      // description: "dutchieplus is a just a test description"
+    case "dutchie":
+      import("../shared/environment-data-sources/dutchie").then(({ default: load }): void => load());
+      // description: "dutchie is a just a test description"
       // events-tracked: [{ value: "add_to_cart", label: "Add to Cart" }, { value: "remove_from_cart", label: "Remove from Cart" }, { "value": "transaction", "label": "Transaction" }]
       break;
     case "ecwid":

--- a/src/shared/environment-data-sources/dutchie.ts
+++ b/src/shared/environment-data-sources/dutchie.ts
@@ -1,0 +1,11 @@
+import dutchieSubdomainDataSource from "./dutchie-subdomain";
+import dutchieIframeDataSource from "./dutchie-iframe";
+import dutchiePlusDataSource from "./dutchie-plus";
+
+const dutchieDataSource = () => {
+    dutchiePlusDataSource();
+    dutchieIframeDataSource();
+    dutchieSubdomainDataSource();
+};
+
+export default dutchieDataSource;


### PR DESCRIPTION
This pull request includes significant changes to the way Dutchie data sources are imported and managed. The main changes involve consolidating multiple Dutchie-related imports into a single import and updating the corresponding case in the `ecommerce.ts` file.

### Consolidation of Dutchie Imports:

* [`src/adapters/ecommerce.ts`](diffhunk://#diff-fd24e953cfd3e4c04096be9762739fbdc8cb7f37ca36b9b0145ce868769ebd2cL43-R45): Consolidated the `dutchie-iframe`, `dutchie-subdomain`, and `dutchieplus` cases into a single `dutchie` case. The new case imports from `../shared/environment-data-sources/dutchie`.
* [`src/shared/environment-data-sources/dutchie.ts`](diffhunk://#diff-ac57578af856fa92883a9e412098728f46def208731d6adc7226387e891a9bbcR1-R11): Created a new `dutchieDataSource` function that imports and executes `dutchie-subdomain`, `dutchie-iframe`, and `dutchie-plus` data sources. This function is exported as the default export.