### PR TITLE
[HOTFIX] Added new tags cloudfront

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,13 @@ jobs:
           distribution_id: EQGTP3X7S8LMI
           paths: /*
       - aws-cloudfront/invalidate:
-          distribution_id: EFJHMMZDNURYT
+          distribution_id: E39XLCEMWS6VO1
+          paths: /*
+      - aws-cloudfront/invalidate:
+          distribution_id: E270PRY60O4B3Y
+          paths: /*
+      - aws-cloudfront/invalidate:
+          distribution_id: ELFZ8CP0408WK
           paths: /*
       - run:
           name: Run Tracker


### PR DESCRIPTION
This pull request updates the `.circleci/config.yml` file to modify and expand the AWS CloudFront invalidation jobs. The changes ensure that additional distributions are invalidated during the CI/CD pipeline.

Updates to AWS CloudFront invalidation jobs:

* Updated the `distribution_id` for an existing invalidation job from `EFJHMMZDNURYT` to `E39XLCEMWS6VO1`.
* Added three new invalidation jobs for the following `distribution_id` values: `E270PRY60O4B3Y`, `ELFZ8CP0408WK`, and `EQGTP3X7S8LMI`.