### PR TITLE
Add getAppIdTags function for importing external scripts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { QueryStringContext } from './shared/types';
 import getContext from './shared/utils/get-context';
 import { getCustomTags } from './shared/utils/get-custom-tags';
 import { datasourceLogger } from './shared/utils/datasource-logger';
+import { getAppIdTags } from './shared/utils/get-appId-tags';
 
 (async (): Promise<void> => {
   try {
@@ -12,6 +13,7 @@ import { datasourceLogger } from './shared/utils/datasource-logger';
     const context: QueryStringContext = getContext();
 
     await getCustomTags();
+    await getAppIdTags();
 
     const overrides = window.overrides ? window.overrides : { "s3.pv": "00000", "s3.tr": "00000" }
     

--- a/src/shared/utils/get-appId-tags.ts
+++ b/src/shared/utils/get-appId-tags.ts
@@ -1,0 +1,23 @@
+import logger from 'src/shared/logger';
+import getContext from './get-context';
+import { QueryStringContext } from '../types';
+
+export const getAppIdTags = async () => {
+    const context: QueryStringContext = getContext();
+    const id = `${process.env.FRICTIONLESS_CUSTOMTAG_APPID}/app-ids/${context.appId}.js`;
+
+    try {
+        const response = await fetch(id);
+
+        const scriptText = await response.text();
+        const script = document.createElement("script");
+        script.type = "text/javascript";
+
+        script.text = scriptText;
+        document.head.appendChild(script);
+        logger.info(`Successfully imported external script from ${id}`);
+    } catch (error) {
+        logger.warn(`Failed to import script from ${id}: ${error}`);
+        return;
+    } 
+}


### PR DESCRIPTION
Allows us to use App Ids in the frictionless repo to add custom scripts for tracking `src/app-ids`