### PR TITLE
Update datasource and custom tag retrieval functions

### DIFF
--- a/src/shared/utils/datasource-logger.ts
+++ b/src/shared/utils/datasource-logger.ts
@@ -1,43 +1,44 @@
 import { datalayerSource } from "../sources/google-datalayer-source";
 import { xhrRequestSource, formatXhrPayload } from "../sources/xhr-request-source";
-import {  xhrResponseSource } from "../sources/xhr-response-source";
+import { xhrResponseSource } from "../sources/xhr-response-source";
 import { fetchSource } from "../sources/fetch-source";
 import { createLogger } from "../logger";
 
 export const datasourceLogger = (): void => {
-    const logger = createLogger("DataSourceLogger");
+  const logger = createLogger("DataSourceLogger");
 
-    datalayerSource((data) => {
-        logger.info("DataLayer Source Data:", data);
-    });
+  datalayerSource((data) => {
+    console.log("DataLayer Source Data:", data);
+  });
 
-    xhrResponseSource((xhr) => {
-        try {
-            logger.info('xhr Response Source Data: ', xhr);
-        } catch  (e) {}
-    });
+  xhrResponseSource((xhr) => {
+    try {
+      if (xhr.responseURL == "https://otel.highlight.io/v1/metrics") return;
+      console.log("xhr Response Source Data: ", xhr);
+    } catch (e) {}
+  });
 
-    xhrRequestSource((xhr) => {
-        try {
-            const sanitizedData = formatXhrPayload(xhr);
-            logger.info('xhr Request Source Data: ', sanitizedData);
-        } catch (e) {}
-    });
+  xhrRequestSource((xhr) => {
+    try {
+      const sanitizedData = formatXhrPayload(xhr);
+      console.log("xhr Request Source Data: ", sanitizedData);
+    } catch (e) {}
+  });
 
-    window.addEventListener("Event Listener Message1", (event) => logger.info('post message data',event), false);
+  window.addEventListener("message", (event) => console.log("post message data", event), false);
 
-    const postMessageSource = function(callback) {
-        window.addEventListener("Post Message Data", callback, false);
-      };
-    
-    postMessageSource((event) => logger.info('Post Message Data: ', event));
+  const postMessageSource = function (callback) {
+    window.addEventListener("message", callback, false);
+  };
 
-    fetchSource(
-        (request) => {},
-        (response, responseBody) => {
-            try {
-                logger.info('fetch response: ', responseBody);
-            } catch (e) {}
-        }
-      );
-}
+  postMessageSource((event) => console.log("Post Message Data: ", event));
+
+  fetchSource(
+    (request) => {},
+    (response, responseBody) => {
+      try {
+        console.log("fetch response: ", responseBody);
+      } catch (e) {}
+    },
+  );
+};

--- a/src/shared/utils/get-appId-tags.ts
+++ b/src/shared/utils/get-appId-tags.ts
@@ -1,23 +1,32 @@
-import logger from 'src/shared/logger';
-import getContext from './get-context';
-import { QueryStringContext } from '../types';
+import logger from "src/shared/logger";
+import getContext from "./get-context";
+import { QueryStringContext } from "../types";
 
 export const getAppIdTags = async () => {
-    const context: QueryStringContext = getContext();
-    const id = `${process.env.FRICTIONLESS_CUSTOMTAG_APPID}/app-ids/${context.appId}.js`;
+  const context: QueryStringContext = getContext();
 
-    try {
-        const response = await fetch(id);
+  if (!context.appId) {
+    return;
+  }
 
-        const scriptText = await response.text();
-        const script = document.createElement("script");
-        script.type = "text/javascript";
+  const id = `${process.env.FRICTIONLESS_CUSTOMTAG_URL}/app-ids/${Buffer.from(context.appId, "utf-8").toString("base64")}.js`;
 
-        script.text = scriptText;
-        document.head.appendChild(script);
-        logger.info(`Successfully imported external script from ${id}`);
-    } catch (error) {
-        logger.warn(`Failed to import script from ${id}: ${error}`);
-        return;
-    } 
-}
+  try {
+    const response = await fetch(id);
+
+    if (!response.ok) {
+      return;
+    }
+
+    const scriptText = await response.text();
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+
+    script.text = scriptText;
+    document.head.appendChild(script);
+    logger.info(`Successfully imported external script from ${id}`);
+  } catch (error) {
+    logger.warn(`Failed to import script from ${id}: ${error}`);
+    return;
+  }
+};

--- a/src/shared/utils/get-custom-tags.ts
+++ b/src/shared/utils/get-custom-tags.ts
@@ -1,4 +1,4 @@
-import logger from 'src/shared/logger';
+import logger from "src/shared/logger";
 
 export const getCustomTags = async () => {
   const hname = window.location.hostname;
@@ -7,9 +7,17 @@ export const getCustomTags = async () => {
   try {
     const response = await fetch(url);
 
+    if (!response.ok) {
+      return;
+    }
+
     const scriptText = await response.text();
     const script = document.createElement("script");
     script.type = "text/javascript";
+
+    if (scriptText.trim().startsWith("<") || scriptText.includes("<!DOCTYPE")) {
+      return;
+    }
 
     script.text = scriptText;
     document.head.appendChild(script);


### PR DESCRIPTION
# Description
* Remove logger on datasource logs and use console log instead.
* Fix following below by adding validation on `scriptText`.
  ```
  Uncaught SyntaxError: Failed to execute 'appendChild' on 'Node': Unexpected token '<'
      at getCustomTags
  ```
* Add FRICTIONLESS_CUSTOMTAG_URL env on get-appId-tags.
* Add validation on `context.appId` if value is undefined before declaring with buffer before base64 encoding.

## Screenshot of results
![Uploading image.png…]()
