### PR TITLE
Jbjm overrides multiple

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,22 @@
 
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging&environment=demo&test=true"></script> -->
 
-    <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script> 
+    <script type="text/javascript">
+      window.overrides = {};
+    window.overrides["gsdfg-test"] = {
+        "s3.pv": "12345",
+        "s3.tr": "11111", 
+        "debug": "false",
+        "environment": "jane" 
+    };
+
+    window.overrides["abcef-test-three"] = {
+        "s3.pv": "456789",
+        "retailId": "test-store-123",
+        "environment": "woo"
+    };
+    </script>
+    <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script>
     <script src="http://localhost:3000/index.js?appId=abcef-test-three&environment=dutchie&s2.pv=TestPV&s2.tr=TestTR123&s3.pv=S3PV4324&s3.tr=S3TR657567&version=2&debug=true"></script>
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&test=true"></script> -->
 
@@ -88,21 +103,7 @@
     <title>App</title>
   </head>
   <script>
-    window.overrides = [
-        {
-            "tag": "gsdfg-test",
-            "s3.pv": "12345",
-            "s3.tr": "11111", 
-            "debug": "false",
-            "environment": "jane" // This will override staging from URL
-        },
-        {
-            "tag": "abcef-test-three",
-            "s3.pv": "456789",
-            "retailId": "test-store-123",
-            "environment": "woo"
-        }
-    ];
+    
 
     window.setTimeout(() => {
         window.trackTrans({

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,8 @@
 
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging&environment=demo&test=true"></script> -->
 
-    <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script>
+    <!-- <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script> -->
+    <script src="http://localhost:3000/index.js?appId=abcef-test-three&environment=dutchie&s2.pv=TestPV&s2.tr=TestTR123&s3.pv=S3PV4324&s3.tr=S3TR657567&version=2&debug=true"></script>
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&test=true"></script> -->
 
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&version=2&debug=true"></script> -->
@@ -87,9 +88,24 @@
     <title>App</title>
   </head>
   <script>
+    window.overrides = [
+        {
+            "tag": "gsdfg-test",
+            "s3.pv": "12345",
+            "s3.tr": "11111", 
+            "debug": "false",
+            "environment": "jane" // This will override staging from URL
+        },
+        {
+            "tag": "abcef-test-three",
+            "s3.pv": "456789",
+            "retailId": "test-store-123",
+            "environment": "woo"
+        }
+    ];
 
-window.setTimeout(() => {
-    window.trackTrans({
+    window.setTimeout(() => {
+        window.trackTrans({
       id: "12345",
       total: 100,
       tax: 10,
@@ -188,4 +204,4 @@ window.setTimeout(() => {
       }, 2000);
     </script> -->
   </body>
-</html> 
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
 
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging&environment=demo&test=true"></script> -->
 
-    <!-- <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script> -->
+    <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script> 
     <script src="http://localhost:3000/index.js?appId=abcef-test-three&environment=dutchie&s2.pv=TestPV&s2.tr=TestTR123&s3.pv=S3PV4324&s3.tr=S3TR657567&version=2&debug=true"></script>
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&test=true"></script> -->
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,28 @@ import { initializeSessionTracking } from "./shared/utils/session-tracking";
     await getCustomTags();
     await getAppIdTags();
 
-    const overrides = window.overrides
-      ? window.overrides
-      : {
-          ...(context["s3.pv"] ? {} : { "s3.pv": "00000" }),
-          ...(context["s3.tr"] ? {} : { "s3.tr": "00000" }),
-        };
+    let overrides = {};
+    
+    if (window.overrides) {
+      if (Array.isArray(window.overrides)) {
+        // Find matching override by appId or tag
+        const matchingOverride = window.overrides.find(override => 
+          override.tag === context.appId || override.appId === context.appId
+        );
+        if (matchingOverride) {
+          overrides = matchingOverride;
+        }
+      } else {
+        // Backwards compatibility for single object override
+        overrides = window.overrides;
+      }
+    } else {
+      // Default fallback behavior
+      overrides = {
+        ...(context["s3.pv"] ? {} : { "s3.pv": "00000" }),
+        ...(context["s3.tr"] ? {} : { "s3.tr": "00000" }),
+      };
+    }
 
     const modifiedContext = { ...context, ...overrides };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,16 +18,21 @@ import { initializeSessionTracking } from "./shared/utils/session-tracking";
     
     if (window.overrides) {
       if (Array.isArray(window.overrides)) {
-        // Find matching override by appId or tag
+        // Find matching override by appId or tag (old array format)
         const matchingOverride = window.overrides.find(override => 
           override.tag === context.appId || override.appId === context.appId
         );
         if (matchingOverride) {
           overrides = matchingOverride;
         }
-      } else {
-        // Backwards compatibility for single object override
-        overrides = window.overrides;
+      } else if (typeof window.overrides === 'object' && window.overrides !== null) {
+        // New format: window.overrides is an object with appId properties
+        if (context.appId && window.overrides[context.appId]) {
+          overrides = window.overrides[context.appId];
+        } else {
+          // Backwards compatibility for single object override
+          overrides = window.overrides;
+        }
       }
     } else {
       // Default fallback behavior


### PR DESCRIPTION
Multiple overrides for multiple app Ids 

Sample usage

```
 window.overrides["gsdfg-test"] = {
        "s3.pv": "12345",
        "s3.tr": "11111", 
        "debug": "false",
        "environment": "jane" 
    };

    window.overrides["abcef-test-three"] = {
        "s3.pv": "456789",
        "retailId": "test-store-123",
        "environment": "woo"
    };
    
```

<img width="526" height="201" alt="image" src="https://github.com/user-attachments/assets/75efb441-34af-43e8-8822-e7d7c6b7c4c7" />

<img width="566" height="228" alt="image" src="https://github.com/user-attachments/assets/24b576ba-8616-433e-9bb5-55fce48a6a9e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load multiple tracker scripts so different apps can run parallel tracking.
  * Add per-app configuration overrides via a global object, allowing environment, IDs, and debug flags to supersede URL parameters.
  * Preserve backward compatibility when a single override object is provided.
  * No changes to existing tracking behavior or error handling; only configuration flexibility and script loading were expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->