### PR TITLE
Added feature to enable and disable tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,21 +11,18 @@ import { initializeSessionTracking } from "./shared/utils/session-tracking";
   try {
     const context: QueryStringContext = getContext();
 
-    await getCustomTags();
-    await getAppIdTags();
-
     let overrides = {};
-    
+
     if (window.overrides) {
       if (Array.isArray(window.overrides)) {
         // Find matching override by appId or tag (old array format)
-        const matchingOverride = window.overrides.find(override => 
-          override.tag === context.appId || override.appId === context.appId
+        const matchingOverride = window.overrides.find(
+          (override) => override.tag === context.appId || override.appId === context.appId,
         );
         if (matchingOverride) {
           overrides = matchingOverride;
         }
-      } else if (typeof window.overrides === 'object' && window.overrides !== null) {
+      } else if (typeof window.overrides === "object" && window.overrides !== null) {
         // New format: window.overrides is an object with appId properties
         if (context.appId && window.overrides[context.appId]) {
           overrides = window.overrides[context.appId];
@@ -43,6 +40,14 @@ import { initializeSessionTracking } from "./shared/utils/session-tracking";
     }
 
     const modifiedContext = { ...context, ...overrides };
+
+    if (modifiedContext.enable === "false") {
+      logger.debug("Tag has been disabled. Reach out to your pixel provider for more information.");
+      return;
+    }
+
+    await getCustomTags();
+    await getAppIdTags();
 
     logger.debug("MJ Tag Context", modifiedContext);
     logger.debug("Integrations In Progress");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -158,6 +158,10 @@ export type DatasourceTrackerParam = {
   debug: string;
 };
 
+export type enableTagParam = {
+  enable: "true" | "false";
+};
+
 export type QueryStringParams = Partial<TransactionParams> &
   Partial<SignupParams> &
   Partial<SnowplowPluginParams> &
@@ -167,7 +171,8 @@ export type QueryStringParams = Partial<TransactionParams> &
   BingAdsPluginParams &
   SnowplowParams &
   SegmentParams &
-  DatasourceTrackerParam;
+  DatasourceTrackerParam &
+  enableTagParam;
 
 // Params available to the tag's query string
 export type QueryStringContext = QueryStringParams & { collector: string };


### PR DESCRIPTION
How to Use:
1. On the index.html file, modify the tag to have `enable=false` 
2. Run `yarn start`
3. Check console and snowplow if tag is still there and if we're tracking pageviews and transactions

Screenshots:
<img width="1907" height="505" alt="image" src="https://github.com/user-attachments/assets/2f47db4f-320c-49b4-bce3-b1e706981a1b" />
<img width="1908" height="425" alt="image" src="https://github.com/user-attachments/assets/a451c6f8-7072-4af5-9059-6d8f5cbcfcee" />

(We have a script that triggers a transaction after visiting localhost, we should not be able to track)
<img width="727" height="654" alt="image" src="https://github.com/user-attachments/assets/f0f1d6ba-991a-4747-81dd-7cb6d9931d34" />
