### PR TITLE
remove legacy overrides

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
     window.overrides["gsdfg-test"] = {
         "s3.pv": "12345",
         "s3.tr": "11111", 
+        "s2.tr": "888",
         "debug": "false",
         "environment": "jane" 
     };
@@ -27,8 +28,8 @@
         "environment": "woo"
     };
     </script>
-    <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=true"></script>
-    <script src="http://localhost:3000/index.js?appId=abcef-test-three&environment=dutchie&s2.pv=TestPV&s2.tr=TestTR123&s3.pv=S3PV4324&s3.tr=S3TR657567&version=2&debug=true"></script>
+    <script src="http://localhost:3000/index.js?appId=gsdfg-test&environment=dummy-cart&s2.pv=TestPV&s2.tr=TestTR&s3.pv=S3PV&s3.tr=S3TR&version=2&debug=false"></script>
+    <script src="http://localhost:3000/index.js?appId=abcef-test-three&environment=dutchie&s2.pv=TestPV&s2.tr=TestTR123&s3.pv=S3PV4324&s3.tr=S3TR657567&version=2&debug=false"></script>
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&test=true"></script> -->
 
     <!-- <script src="http://localhost:3000/index.js?appId=universal-tag-staging-test&version=2&debug=true"></script> -->

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,16 +17,7 @@ import { initializeSessionTracking } from "./shared/utils/session-tracking";
     let overrides = {};
     
     if (window.overrides) {
-      if (Array.isArray(window.overrides)) {
-        // Find matching override by appId or tag (old array format)
-        const matchingOverride = window.overrides.find(override => 
-          override.tag === context.appId || override.appId === context.appId
-        );
-        if (matchingOverride) {
-          overrides = matchingOverride;
-        }
-      } else if (typeof window.overrides === 'object' && window.overrides !== null) {
-        // New format: window.overrides is an object with appId properties
+      if (typeof window.overrides === 'object' && window.overrides !== null) {
         if (context.appId && window.overrides[context.appId]) {
           overrides = window.overrides[context.appId];
         } else {


### PR DESCRIPTION
Remove legacy overrides

<img width="1169" height="374" alt="image" src="https://github.com/user-attachments/assets/5253b652-1ec0-4b00-b588-ab424dd06a63" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a new override setting for gsdfg-test (s2.tr = "888").
  * Improved per-app configuration by resolving overrides by app ID when available.

* Refactor
  * Removed support for legacy array-based overrides; single-object and per-app overrides continue to work.

* Chores
  * Switched embedded script loads to non-debug mode for gsdfg-test and abcef-test-three to reduce console noise and improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->