### PR TITLE
Update ENV to COLLECTOR URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ Fire third-party audience beacons alongside tracking:
 ### `window.overrides`
 
 Define `window.overrides` **before** the tag loads to override context values per `appId` (e.g. a
-custom `collector` or `logs`). The collector itself defaults from the `MJ_PRODUCTION_COLLECTOR_URL`
-/ `MJ_STAGING_COLLECTOR_URL` env vars baked at build time.
+custom `collector` or `logs`). The collector itself defaults from the `COLLECTOR_URL`
+env var baked at build time.
 
 ```html
 <script>

--- a/packages/tracker-core/src/snowplow/v1/init.ts
+++ b/packages/tracker-core/src/snowplow/v1/init.ts
@@ -34,7 +34,7 @@ export const initialize = ({ appId, collector, event, sdkUrl }: SnowplowTrackerI
   });
 
   // Second tracker for new pipeline collector
-  window.tracker("newTracker", appId, "collector-latest.dmp.cnna.io", {
+  window.tracker("newTracker", appId, process.env.COLLECTOR_URL, {
     appId: appId,
     postPath: "/analytics/track",
     discoverRootDomain: true,

--- a/packages/tracker-core/src/snowplow/v2/init.ts
+++ b/packages/tracker-core/src/snowplow/v2/init.ts
@@ -34,7 +34,7 @@ export const initialize = ({ appId, collector, event, sdkUrl }: SnowplowTrackerI
     eventMethod: "post",
   });
   // Second tracker for new pipeline collector
-  window.tracker("newTracker", `${appId}_v2`, "collector-latest.dmp.cnna.io", {
+  window.tracker("newTracker", `${appId}_v2`, process.env.COLLECTOR_URL, {
     appId,
     postPath: "/analytics/track",
     discoverRootDomain: true,

--- a/packages/tracker-core/src/utils/get-context.ts
+++ b/packages/tracker-core/src/utils/get-context.ts
@@ -19,7 +19,7 @@ const getContext = (): QueryStringContext => {
     appId: appId || mediajelAppId || "", // Legacy support for old universal tag
     version: version || "1", // tracker version
     environment: params.environment || "production",
-    collector: (params.test ? process.env.MJ_STAGING_COLLECTOR_URL : process.env.MJ_PRODUCTION_COLLECTOR_URL) || "",
+    collector: process.env.COLLECTOR_URL || "",
     // Regex mainly used to remove the "&amp;" and the '\\"' from the outerHTML
     tag: target.outerHTML.replace(/&amp;/g, "&").replace(/\\"/g, '"'),
   };


### PR DESCRIPTION
This pull request updates the way the collector URL is configured and used throughout the tracker codebase. Instead of relying on separate environment variables for production and staging collector URLs, the code now uses a single `COLLECTOR_URL` environment variable. This change simplifies configuration and ensures consistency across different environments.

**Environment variable consolidation and usage:**

* Updated the `getContext` utility in `get-context.ts` to use `process.env.COLLECTOR_URL` instead of separate production and staging collector URLs.
* Modified both Snowplow tracker initializers (`v1/init.ts` and `v2/init.ts`) to use `process.env.COLLECTOR_URL` for the collector endpoint, replacing the hardcoded domain. [[1]](diffhunk://#diff-904e0fa2da98ad6f83fc2f5b033a923d44900d954f657007e9e4ba9ad1102f40L37-R37) [[2]](diffhunk://#diff-6ca3543087bb65083cd6d098548185d9f7680410bbd80a6a98793fad12d061f4L37-R37)

**Documentation update:**

* Updated the `README.md` to reference `COLLECTOR_URL` as the default collector environment variable, removing mention of the old production and staging variables.