### PR TITLE
Expose build-time env vars to Parcel 

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
+  // Parcel inlines these into the tag bundle. Declare them so turbo's strict mode (default)
+  // doesn't drop them in CI. globalEnv (not passThroughEnv) also busts the cache when they change.
+  "globalEnv": ["COLLECTOR_URL", "FRICTIONLESS_CUSTOMTAG_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Turbo's strict env mode (the default) dropped COLLECTOR_URL and FRICTIONLESS_CUSTOMTAG_URL from `turbo run build` in CI, so Parcel inlined them as undefined and the v2 tracker shipped a null collector in staging. Declare them in turbo.json globalEnv so turbo passes them through and busts the build cache when they change.