### PR TITLE
Add Posabit adapter to the tracker

### DIFF
--- a/apps/tracker/src/adapters/ecommerce.ts
+++ b/apps/tracker/src/adapters/ecommerce.ts
@@ -233,6 +233,11 @@ export default async (tracker: SnowplowTracker): Promise<void> => {
       // description: "treez is a just a test descriptions"
       // events-tracked: [{ "value": "transaction", "label": "Transaction" }]
       break;
+    case "posabit":
+      import("@mediajel/tracker-environments/environment-data-sources/posabit").then(({ default: load }): void => load());
+      // description: "posabit is a just a test description"
+      // events-tracked: [{ "value": "add_to_cart", "label": "Add to Cart" }, { "value": "transaction", "label": "Transaction" }]
+      break;
 
       default:
         logger.warn("No event/environment specified, Only pageview is active");

--- a/packages/tracker-environments/src/environment-data-sources/posabit.ts
+++ b/packages/tracker-environments/src/environment-data-sources/posabit.ts
@@ -1,0 +1,67 @@
+import observable from "@mediajel/tracker-core/utils/create-events-observable";
+import { datalayerSource } from "@mediajel/tracker-core/sources/google-datalayer-source";
+import { isTrackerLoaded } from "@mediajel/tracker-core/sources/utils/is-tracker-loaded";
+import { TransactionCartItem } from "@mediajel/tracker-core/types";
+
+const posabitDataSource = () => {
+  isTrackerLoaded(() => {
+    datalayerSource((data: any) => {
+      // Posabit menus push GA4 gtag args-style events: data["0"] = "event", data["1"] = name, data["2"] = payload
+      if (data?.["0"] === "event" && data?.["1"] === "purchase") {
+        const transaction = data["2"];
+        const products = transaction?.items;
+        if (!transaction || !Array.isArray(products)) return;
+
+        const transactionId = transaction.transaction_id?.toString() || "N/A";
+
+        observable.notify({
+          transactionEvent: {
+            id: transactionId,
+            total: parseFloat(transaction.value) || 0,
+            tax: parseFloat(transaction.tax) || 0,
+            shipping: parseFloat(transaction.shipping) || 0,
+            city: "N/A",
+            state: "N/A",
+            country: "N/A",
+            currency: "USD",
+            items: products.map(
+              (item: any) =>
+                ({
+                  orderId: transactionId,
+                  sku: item.item_id?.toString() || "N/A",
+                  name: item.item_name?.toString() || "N/A",
+                  category: "N/A",
+                  unitPrice: parseFloat(item.price) || 0,
+                  quantity: parseInt(item.quantity) || 1,
+                  currency: "USD",
+                }) as TransactionCartItem,
+            ),
+          },
+        });
+      }
+
+      if (data?.["0"] === "event" && data?.["1"] === "add_to_cart") {
+        const cart = data["2"];
+        const products = cart?.items;
+        if (!cart || !Array.isArray(products)) return;
+
+        const currency = (cart.currency || "USD").toString();
+
+        products.forEach((item: any) => {
+          observable.notify({
+            addToCartEvent: {
+              sku: item.item_id?.toString() || "N/A",
+              name: item.item_name?.toString() || "N/A",
+              category: "N/A",
+              unitPrice: parseFloat(item.price) || 0,
+              quantity: parseInt(item.quantity) || 1,
+              currency,
+            },
+          });
+        });
+      }
+    });
+  });
+};
+
+export default posabitDataSource;


### PR DESCRIPTION
Ticket Issue: https://github.com/MediaJel/mediajel-dashboard/issues/11485

## What this does

  Adds Posabit as a new tracker environment (`environment=posabit`), so we can
  track sales and add-to-cart events on Posabit-hosted dispensary menus.
 
  Posabit menus push GA4 gtag-style events into the dataLayer, e.g.
  `{ "0": "event", "1": "add_to_cart", "2": { ...payload... } }`.
  The adapter reads those, maps them to our transaction and add-to-cart events,
  and hands them to the tracker.
  
  This is a port of the existing Posabit tracking code from
  `mediajel-frictionless-custom-tag` into the tracker as a proper adapter.

This follows the same shape as the existing `foxy` / `treez` adapters.

Related PR: 

## How it was tested

  - `bun run check` — typecheck passes across all 4 packages.
  - `bun x turbo run build --filter=mediajel-tracker` — builds, emits `dist/posabit.7adfe6c5.js`.
  - Loaded the tag locally with `environment=posabit` and pushed the exact `add_to_cart`
    payload from the ticket. Confirmed in the console that the adapter loaded
    ("Loading posabit"), parsed both event types, and that Snowplow built and sent a
    payload containing them.
   
  ## Known open item
   
  The `add_to_cart` payload in the ticket is real, but I did not have a real Posabit
  **purchase** payload to work from. The transaction mapping assumes the standard GA4
  fields (`transaction_id`, `value`, `tax`, `shipping`, `items[]`).