### PR TITLE
fix(tracker): add basket_items to carrot events-tracked annotation

### DIFF
--- a/apps/tracker/src/adapters/ecommerce.ts
+++ b/apps/tracker/src/adapters/ecommerce.ts
@@ -226,7 +226,7 @@ export default async (tracker: SnowplowTracker): Promise<void> => {
     case "carrot":
       import("@mediajel/tracker-environments/environment-data-sources/carrot").then(({ default: load }): void => load(tracker));
       // description: "carrot is a just a test descriptions"
-      // events-tracked: [{ "value": "transaction", "label": "Transaction" }]
+      // events-tracked: [{ "value": "transaction", "label": "Transaction" }, { "value": "basket_items", "label": "Basket Items" }]
       break;
     case "treez":
       import("@mediajel/tracker-environments/environment-data-sources/treez").then(({ default: load }): void => load());


### PR DESCRIPTION
## Summary
Adds `basket_items` to the **carrot** cart's `// events-tracked:` annotation in `apps/tracker/src/adapters/ecommerce.ts` — the source of truth for which measurements each cart supports on the dashboard.

## Why
These annotations are regex-parsed by `generateEnvironments.ts` and uploaded to `s3://mjcarts/environments.js` (CI `build-main` job). That S3 file is what the internal-service serves via `GET /api/tracker/environments/events` → gql `getCarts` → the dashboard's cart **Supported Measurements** and the campaign-launcher **Basket Items** toggle. Carrot's annotation listed only `transaction`, so the launcher greys out Basket Items for carrot campaigns — even though carrot genuinely tracks basket items: **2,598 `transaction_item` Snowplow events in 14 days** for the Seaweed carrot tag (verified in prod ClickHouse).

## Change
One line — carrot's annotation: `[transaction]` → `[transaction, basket_items]`.

## Verification
Simulated the generator's exact regex + `JSON.parse` over the edited file: **39 carts parsed; only carrot changes; the other 38 are byte-identical** to the current annotations. Fully-quoted JSON — parses cleanly.

## Ship path / caveats
- The S3 upload runs **only in the `build-main` CI job** — merging to `staging` does not refresh `environments.js`; it takes effect when this reaches `main`. Note `main` is still on the pre-turborepo layout — its copy of this annotation is `src/adapters/ecommerce.ts:215` and needs the same one-liner if the release to `main` isn't a straight merge.
- This is the **durable half** of the carrot fix (stops future regenerations from reverting it). The immediate dashboard fix is MediaJel/amplication-nestjs-microservices#2341 (edits the generated snapshot directly). Full investigation + remaining work (data-driven pipeline, other carts' missing basket_items annotations): MediaJel/amplication-nestjs-microservices#2340.