### PR TITLE
Disable test pipeline tracker

### DIFF
--- a/packages/tracker-core/src/snowplow/v1/init.ts
+++ b/packages/tracker-core/src/snowplow/v1/init.ts
@@ -23,7 +23,7 @@ export const initialize = ({ appId, collector, event, sdkUrl }: SnowplowTrackerI
   })(window, document, "script", "//dm2q9qfzyjfox.cloudfront.net/sp.js", "tracker");
 
   // Creates the tracker with the appId and sends events to collector url
-  window.tracker("newTracker", `${appId}_v2`, `${collector}`, {
+  window.tracker("newTracker", appId, `${collector}`, {
     appId: appId,
     postPath: "/analytics/track",
     discoverRootDomain: true,

--- a/packages/tracker-core/src/snowplow/v1/init.ts
+++ b/packages/tracker-core/src/snowplow/v1/init.ts
@@ -29,17 +29,6 @@ export const initialize = ({ appId, collector, event, sdkUrl }: SnowplowTrackerI
     discoverRootDomain: true,
     stateStorageStrategy: "cookieAndLocalStorage",
     cookieSameSite: "Lax",
-    respectDoNotTrack: false,
-    eventMethod: "post",
-  });
-
-  // Second tracker for new pipeline collector
-  window.tracker("newTracker", appId, process.env.COLLECTOR_URL, {
-    appId: appId,
-    postPath: "/analytics/track",
-    discoverRootDomain: true,
-    stateStorageStrategy: "cookieAndLocalStorage",
-    cookieSameSite: "Lax",
     // Privacy-compliant posture: first-party Secure cookies, and honor Do Not Track at the SDK
     // level too. The tag's edge gate (isUsPrivacyOptOut) already hard-exits on GPC/DNT before the
     // tracker loads; respectDoNotTrack is a second, SDK-level guard so DNT is still honored on any
@@ -48,6 +37,20 @@ export const initialize = ({ appId, collector, event, sdkUrl }: SnowplowTrackerI
     respectDoNotTrack: true,
     eventMethod: "post",
   });
+
+  // Second tracker for new pipeline collector.
+  // Disabled: intended for testing the new pipeline collector, so events are not
+  // double-sent in normal operation.
+  // window.tracker("newTracker", appId, process.env.COLLECTOR_URL, {
+  //   appId: appId,
+  //   postPath: "/analytics/track",
+  //   discoverRootDomain: true,
+  //   stateStorageStrategy: "cookieAndLocalStorage",
+  //   cookieSameSite: "Lax",
+  //   cookieSecure: true,
+  //   respectDoNotTrack: true,
+  //   eventMethod: "post",
+  // });
 
   window.tracker("enableActivityTracking", 30, 10);
   window.tracker("trackPageView");

--- a/packages/tracker-core/src/snowplow/v2/init.ts
+++ b/packages/tracker-core/src/snowplow/v2/init.ts
@@ -33,16 +33,18 @@ export const initialize = ({ appId, collector, event, sdkUrl }: SnowplowTrackerI
     respectDoNotTrack: true,
     eventMethod: "post",
   });
-  // Second tracker for new pipeline collector
-  window.tracker("newTracker", `${appId}_v2`, process.env.COLLECTOR_URL, {
-    appId,
-    postPath: "/analytics/track",
-    discoverRootDomain: true,
-    stateStorageStrategy: "cookieAndLocalStorage",
-    cookieSameSite: "Lax",
-    respectDoNotTrack: false,
-    eventMethod: "post",
-  });
+  // Second tracker for new pipeline collector.
+  // Disabled: intended for testing the new pipeline collector, so events are not
+  // double-sent in normal operation.
+  // window.tracker("newTracker", `${appId}_v2`, process.env.COLLECTOR_URL, {
+  //   appId,
+  //   postPath: "/analytics/track",
+  //   discoverRootDomain: true,
+  //   stateStorageStrategy: "cookieAndLocalStorage",
+  //   cookieSameSite: "Lax",
+  //   respectDoNotTrack: false,
+  //   eventMethod: "post",
+  // });
   window.tracker("enableActivityTracking", {
     minimumVisitLength: 30,
     heartbeatDelay: 10,


### PR DESCRIPTION
Both Snowplow init paths registered a second tracker pointed at the new pipeline collector, double-sending every event. 

In v1 the privacy posture (cookieSecure, respectDoNotTrack) had been applied to the second tracker rather than the first, so disabling it as-written would have dropped that posture. We moved those settings onto the surviving tracker instead of keeping the privacy-configured block. 

Note this flips respectDoNotTrack from false to true for v1 sites.